### PR TITLE
feat(cli-compat): allow install from emulsify-cli with default components

### DIFF
--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 01 Mar 2024 19:45:13 GMT
+ * Generated on Fri, 01 Mar 2024 19:50:05 GMT
  */
 
 :root {

--- a/system.emulsify.json
+++ b/system.emulsify.json
@@ -28,19 +28,19 @@
       "components": [
         {
           "name": "images",
-          "structure": "atoms",
+          "structure": "components",
           "required": true,
           "dependency": []
         },
         {
           "name": "links",
-          "structure": "atoms",
+          "structure": "components",
           "required": true,
           "dependency": []
         },
         {
           "name": "text",
-          "structure": "atoms",
+          "structure": "components",
           "required": true,
           "dependency": ["links"]
         }

--- a/system.emulsify.json
+++ b/system.emulsify.json
@@ -24,6 +24,26 @@
           "destinationPath": "./templates",
           "description": "Contains Drupal templates"
         }
+      ],
+      "components": [
+        {
+          "name": "images",
+          "structure": "atoms",
+          "required": true,
+          "dependency": []
+        },
+        {
+          "name": "links",
+          "structure": "atoms",
+          "required": true,
+          "dependency": []
+        },
+        {
+          "name": "text",
+          "structure": "atoms",
+          "required": true,
+          "dependency": ["links"]
+        }
       ]
     }
   ]

--- a/system.emulsify.json
+++ b/system.emulsify.json
@@ -1,5 +1,5 @@
 {
-  "name": "uikit",
+  "name": "emulsify-ui-kit",
   "homepage": "https://github.com/emulsify-ds/emulsify-ui-kit",
   "repository": "https://github.com/emulsify-ds/emulsify-ui-kit.git",
   "structure": [


### PR DESCRIPTION


## Summary

<!-- Summary of the PR -->

This adds some default components so that UI Kit can be installed by emulsify cli.

Related to https://github.com/emulsify-ds/emulsify-cli/issues/233

This allows for this to be installed without major architectural changes to Emulsify CLI


## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [x] Install emulsify like normal `emulsify init "something" --platform drupal <path/to/drupal>
- [x] Go to the installed theme and check out this branch `emulsify system install --repository  https://github.com/emulsify-ds/emulsify-ui-kit.git --checkout update-system-config
- [x] Should have installed with a few default components. `Successfully installed the emulsify-ui-kit system using the drupal variant.`

