### PR TITLE
Emulsif-67: Color contrast now meets WCAG AA standards 

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -13,13 +13,14 @@
 .card__heading {
   @include heading-large($font-size: var(--font-size-h3));
 
-  color: var(--color-text-heading);
+  color: var(--card-color-heading);
   margin: 0;
   line-height: var(--line-height-tight);
 
   &-link {
     @include link;
 
+    color: var(--card-color-heading);
     text-decoration: none;
   }
 }
@@ -27,7 +28,7 @@
 .card__subheading {
   @include heading-medium($font-size: var(--font-size-small));
 
-  color: var(--color-grays-500);
+  color: var(--card-color-subheading);
   margin: 0 0 var(--spacing-md);
   line-height: var(--line-height-tight);
   text-transform: uppercase;

--- a/src/components/docs/examples/_home.scss
+++ b/src/components/docs/examples/_home.scss
@@ -79,7 +79,7 @@
 
   .watch {
     text-align: center;
-    padding: var(--spacing-xxl) var(--spacing-xl);
+    padding: var(--spacing-2xl) var(--spacing-xl);
 
     .watch-h2 {
       @include heading-large;
@@ -92,15 +92,15 @@
   .watch-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: var(--spacing-xxl);
+    gap: var(--spacing-2xl);
     max-width: 1000px;
-    margin: var(--spacing-xxl) auto 0;
+    margin: var(--spacing-2xl) auto 0;
   }
 
   .celebrating {
     background: var(--colors-primary-lighter);
     text-align: center;
-    padding: var(--spacing-xxl) var(--spacing-xl);
+    padding: var(--spacing-2xl) var(--spacing-xl);
 
     &-h2 {
       @include heading-large;
@@ -114,15 +114,15 @@
   .celebrating-grid {
     display: grid;
     grid-template-columns: repeat(1, 1fr);
-    gap: var(--spacing-xxl);
+    gap: var(--spacing-2xl);
     max-width: 775px;
-    margin: var(--spacing-xxl) auto 0;
+    margin: var(--spacing-2xl) auto 0;
   }
 
   .footer {
     background: var(--colors-primary-darker);
     color: var(--colors-white);
-    padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-xxl);
+    padding: var(--spacing-lg) var(--spacing-xl) var(--spacing-2xl);
     margin-top: auto;
     display: flex;
     flex-flow: row nowrap;

--- a/src/components/docs/examples/_program.scss
+++ b/src/components/docs/examples/_program.scss
@@ -2,7 +2,7 @@
   .dynamic {
     background: var(--colors-primary-lighter);
     text-align: center;
-    padding: var(--spacing-xxl) var(--spacing-xl);
+    padding: var(--spacing-2xl) var(--spacing-xl);
 
     .dynamic-h2 {
       @include heading-large;
@@ -28,8 +28,8 @@
   .dynamic-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: var(--spacing-xxl);
+    gap: var(--spacing-2xl);
     max-width: 1000px;
-    margin: var(--spacing-xxl) auto 0;
+    margin: var(--spacing-2xl) auto 0;
   }
 }

--- a/src/components/storybook-styles/storybook.scss
+++ b/src/components/storybook-styles/storybook.scss
@@ -21,7 +21,7 @@
   color: var(--colors-sb-text-heading);
   text-transform: uppercase;
   font-size: var(--font-size-hero);
-  margin: 0 0 var(--spacing-xxl);
+  margin: 0 0 var(--spacing-2xl);
   position: relative;
   font-family: var(--font-family-body), serif !important;
 
@@ -40,7 +40,7 @@
   font-family: var(--font-family-body), serif !important;
   font-size: var(--font-size-h4);
   opacity: var(--opacity-80);
-  margin: var(--spacing-xxl) 0 var(--spacing-md);
+  margin: var(--spacing-2xl) 0 var(--spacing-md);
 }
 
 #root > div {
@@ -95,7 +95,7 @@
   right: 0;
   background-size: cover;
   background-position: bottom right;
-  padding: var(--spacing-xxl) !important;
+  padding: var(--spacing-2xl) !important;
   display: flex;
   justify-content: flex-end;
   flex-flow: column nowrap;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 17 Jun 2024 23:39:53 GMT
+ * Generated on Mon, 17 Jun 2024 23:59:55 GMT
  */
 
 :root {
@@ -119,12 +119,12 @@
   --card-spacing: 1rem;
   --card-color-heading: #0080b7;
   --card-color-subheading: #006089;
-  --button-color-bkg: #0080b7;
+  --button-color-bkg: #005f89;
   --button-color-label: #ffffff;
-  --button-color-bkg-hover: #006089;
+  --button-color-bkg-hover: #00405b;
   --button-color-label-hover: #ffffff;
   --button-color-label-focus: #ffffff;
-  --button-color-bkg-focus: #006089;
+  --button-color-bkg-focus: #00405b;
   --button-padding-x: 1rem;
   --button-padding-x-hover: 1rem;
   --button-padding-x-focus: 1rem;
@@ -139,9 +139,9 @@
   --button-border-width-border-hover: 1px;
   --button-border-width-border-focus: 1px;
   --button-text-case: uppercase;
-  --button-border-color: #0080b7;
-  --button-border-color-hover: #006089;
-  --button-border-color-focus: #006089;
+  --button-border-color: #005f89;
+  --button-border-color-hover: #00405b;
+  --button-border-color-focus: #00405b;
   --button-font-weight-label: Bold;
   --breadcrumb-default: [object Object];
   --breadcrumb-text-default: #545f64;
@@ -166,7 +166,7 @@
   --color-warning-default: #d80f0f;
   --color-link: #005f89;
   --color-link-hover: #00202e;
-  --color-table: #005f89;
+  --color-link-hover-lighter: #00405b;
   --color-black: #000000;
   --color-white: #ffffff;
   --color-emulsify-blue-100: #e6f5fc;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 22:23:10 GMT
+ * Generated on Fri, 14 Jun 2024 22:34:41 GMT
  */
 
 :root {

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 21:39:30 GMT
+ * Generated on Fri, 14 Jun 2024 21:40:35 GMT
  */
 
 :root {
@@ -117,42 +117,8 @@
   --checkbox-button-stroke-disabled: #a9afb1;
   --checkbox-spacing-gap: 0.25rem;
   --card-spacing: 1rem;
-  --color-heading: #0080b7;
-  --color-subheading: #006089;
-  --color-primary-default: #009fe4;
-  --color-primary-light: #1ebbff;
-  --color-primary-lighter: #9ce1ff;
-  --color-primary-dark: #0080b7;
-  --color-primary-darker: #006089;
-  --color-text-body: #00202e;
-  --color-text-body-lighter: #006089;
-  --color-text-heading: #006089;
-  --color-text-white: #ffffff;
-  --color-warning-default: #d80f0f;
-  --color-link: #005f89;
-  --color-link-hover: #00202e;
-  --color-black: #000000;
-  --color-white: #ffffff;
-  --color-emulsify-blue-100: #e6f5fc;
-  --color-emulsify-blue-200: #ccecfa;
-  --color-emulsify-blue-300: #99d9f4;
-  --color-emulsify-blue-400: #66c5ef;
-  --color-emulsify-blue-500: #33b2e9;
-  --color-emulsify-blue-600: #009fe4;
-  --color-emulsify-blue-700: #007fb6;
-  --color-emulsify-blue-800: #005f89;
-  --color-emulsify-blue-900: #00405b;
-  --color-emulsify-blue-1000: #00202e;
-  --color-grays-100: #eaebec;
-  --color-grays-200: #d4d7d8;
-  --color-grays-300: #a9afb1;
-  --color-grays-400: #7f878b;
-  --color-grays-500: #545f64;
-  --color-grays-600: #29373d;
-  --color-grays-700: #212c31;
-  --color-grays-800: #192125;
-  --color-grays-900: #101618;
-  --color-grays-1000: #080b0c;
+  --card-color-heading: #0080b7;
+  --card-color-subheading: #006089;
   --button-color-bkg: #0080b7;
   --button-color-label: #ffffff;
   --button-color-bkg-hover: #006089;
@@ -188,6 +154,40 @@
   --accordion-color-header: #006089;
   --accordion-color-header-hover: #00202e;
   --accordion-divider-color: #545f64;
+  --color-primary-default: #009fe4;
+  --color-primary-light: #1ebbff;
+  --color-primary-lighter: #9ce1ff;
+  --color-primary-dark: #0080b7;
+  --color-primary-darker: #006089;
+  --color-text-body: #00202e;
+  --color-text-body-lighter: #006089;
+  --color-text-heading: #006089;
+  --color-text-white: #ffffff;
+  --color-warning-default: #d80f0f;
+  --color-link: #005f89;
+  --color-link-hover: #00202e;
+  --color-black: #000000;
+  --color-white: #ffffff;
+  --color-emulsify-blue-100: #e6f5fc;
+  --color-emulsify-blue-200: #ccecfa;
+  --color-emulsify-blue-300: #99d9f4;
+  --color-emulsify-blue-400: #66c5ef;
+  --color-emulsify-blue-500: #33b2e9;
+  --color-emulsify-blue-600: #009fe4;
+  --color-emulsify-blue-700: #007fb6;
+  --color-emulsify-blue-800: #005f89;
+  --color-emulsify-blue-900: #00405b;
+  --color-emulsify-blue-1000: #00202e;
+  --color-grays-100: #eaebec;
+  --color-grays-200: #d4d7d8;
+  --color-grays-300: #a9afb1;
+  --color-grays-400: #7f878b;
+  --color-grays-500: #545f64;
+  --color-grays-600: #29373d;
+  --color-grays-700: #212c31;
+  --color-grays-800: #192125;
+  --color-grays-900: #101618;
+  --color-grays-1000: #080b0c;
   --font-family-body: Inter;
   --font-family-heading: Inter;
   --spacing-xs: 0.125rem;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 21:45:33 GMT
+ * Generated on Fri, 14 Jun 2024 22:12:18 GMT
  */
 
 :root {
@@ -57,8 +57,8 @@
   --radio-gap: 0.25rem;
   --pager-color-text-default: #29373d;
   --pager-color-text-hover: #ffffff;
-  --pager-color-text-focus: #009fe4;
-  --pager-color-fill-hover: #009fe4;
+  --pager-color-text-focus: #0080b7;
+  --pager-color-fill-hover: #0080b7;
   --pager-default: [object Object];
   --pager-padding-x: 1rem;
   --pager-padding-x-hover: 1rem;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 21:40:35 GMT
+ * Generated on Fri, 14 Jun 2024 21:45:33 GMT
  */
 
 :root {

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 22:12:18 GMT
+ * Generated on Fri, 14 Jun 2024 22:23:10 GMT
  */
 
 :root {
@@ -23,7 +23,7 @@
   --table-color-cell-bg-stripe: #9ce1ff;
   --table-color-cell-text: #00202e;
   --table-color-cell-icon: #007fb6;
-  --table-color-header-bg: #009fe4;
+  --table-color-header-bg: #007fb6;
   --table-color-header-text: #ffffff;
   --table-color-header-icon: #9ce1ff;
   --table-color-border: #d4d7d8;
@@ -166,6 +166,7 @@
   --color-warning-default: #d80f0f;
   --color-link: #005f89;
   --color-link-hover: #00202e;
+  --color-table: #007fb6;
   --color-black: #000000;
   --color-white: #ffffff;
   --color-emulsify-blue-100: #e6f5fc;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 20:51:41 GMT
+ * Generated on Fri, 14 Jun 2024 21:24:10 GMT
  */
 
 :root {
@@ -16,7 +16,7 @@
   --tabs-color-bg-hover: #ffffff;
   --tabs-color-text-default: #00202e;
   --tabs-color-text-active: #0080b7;
-  --tabs-color-text-hover: #009fe4;
+  --tabs-color-text-hover: #005f89;
   --tabs-color-border-bottom: #a9afb1;
   --tab-label: [object Object];
   --table-color-cell-bg: #ffffff;
@@ -75,8 +75,8 @@
   --main-menu-color-dropdown-bg-hover: #9ce1ff;
   --main-menu-color-dropdown-label: #0080b7;
   --main-menu-color-dropdown-label-hover: #006089;
-  --link-color-default: #009fe4;
-  --link-color-hover: #005f89;
+  --link-color-default: #005f89;
+  --link-color-hover: #00202e;
   --link-body: [object Object];
   --input-gap: 0.5rem;
   --input-padding-x: 1rem;
@@ -117,12 +117,12 @@
   --checkbox-button-stroke-disabled: #a9afb1;
   --checkbox-spacing-gap: 0.25rem;
   --card-spacing: 1rem;
-  --button-color-bkg: #007fb6;
+  --button-color-bkg: #0080b7;
   --button-color-label: #ffffff;
-  --button-color-bkg-hover: #005f89;
+  --button-color-bkg-hover: #006089;
   --button-color-label-hover: #ffffff;
   --button-color-label-focus: #ffffff;
-  --button-color-bkg-focus: #005f89;
+  --button-color-bkg-focus: #006089;
   --button-padding-x: 1rem;
   --button-padding-x-hover: 1rem;
   --button-padding-x-focus: 1rem;
@@ -137,9 +137,9 @@
   --button-border-width-border-hover: 1px;
   --button-border-width-border-focus: 1px;
   --button-text-case: uppercase;
-  --button-border-color: #007fb6;
-  --button-border-color-hover: #005f89;
-  --button-border-color-focus: #005f89;
+  --button-border-color: #0080b7;
+  --button-border-color-hover: #006089;
+  --button-border-color-focus: #006089;
   --button-font-weight-label: Bold;
   --breadcrumb-default: [object Object];
   --breadcrumb-text-default: #545f64;
@@ -150,7 +150,7 @@
   --accordion-p: [object Object];
   --accordion-color-body: #00202e;
   --accordion-color-header: #006089;
-  --accordion-color-header-hover: #007fb6;
+  --accordion-color-header-hover: #00202e;
   --accordion-divider-color: #545f64;
   --color-primary-default: #009fe4;
   --color-primary-light: #1ebbff;
@@ -162,10 +162,8 @@
   --color-text-heading: #006089;
   --color-text-white: #ffffff;
   --color-warning-default: #d80f0f;
-  --color-link: #009fe4;
-  --color-link-hover: #007fb6;
-  --color-button: #007fb6;
-  --color-button-hover: #005f89;
+  --color-link: #005f89;
+  --color-link-hover: #00202e;
   --color-black: #000000;
   --color-white: #ffffff;
   --color-emulsify-blue-100: #e6f5fc;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 21:24:10 GMT
+ * Generated on Fri, 14 Jun 2024 21:39:30 GMT
  */
 
 :root {
@@ -117,6 +117,42 @@
   --checkbox-button-stroke-disabled: #a9afb1;
   --checkbox-spacing-gap: 0.25rem;
   --card-spacing: 1rem;
+  --color-heading: #0080b7;
+  --color-subheading: #006089;
+  --color-primary-default: #009fe4;
+  --color-primary-light: #1ebbff;
+  --color-primary-lighter: #9ce1ff;
+  --color-primary-dark: #0080b7;
+  --color-primary-darker: #006089;
+  --color-text-body: #00202e;
+  --color-text-body-lighter: #006089;
+  --color-text-heading: #006089;
+  --color-text-white: #ffffff;
+  --color-warning-default: #d80f0f;
+  --color-link: #005f89;
+  --color-link-hover: #00202e;
+  --color-black: #000000;
+  --color-white: #ffffff;
+  --color-emulsify-blue-100: #e6f5fc;
+  --color-emulsify-blue-200: #ccecfa;
+  --color-emulsify-blue-300: #99d9f4;
+  --color-emulsify-blue-400: #66c5ef;
+  --color-emulsify-blue-500: #33b2e9;
+  --color-emulsify-blue-600: #009fe4;
+  --color-emulsify-blue-700: #007fb6;
+  --color-emulsify-blue-800: #005f89;
+  --color-emulsify-blue-900: #00405b;
+  --color-emulsify-blue-1000: #00202e;
+  --color-grays-100: #eaebec;
+  --color-grays-200: #d4d7d8;
+  --color-grays-300: #a9afb1;
+  --color-grays-400: #7f878b;
+  --color-grays-500: #545f64;
+  --color-grays-600: #29373d;
+  --color-grays-700: #212c31;
+  --color-grays-800: #192125;
+  --color-grays-900: #101618;
+  --color-grays-1000: #080b0c;
   --button-color-bkg: #0080b7;
   --button-color-label: #ffffff;
   --button-color-bkg-hover: #006089;
@@ -152,40 +188,6 @@
   --accordion-color-header: #006089;
   --accordion-color-header-hover: #00202e;
   --accordion-divider-color: #545f64;
-  --color-primary-default: #009fe4;
-  --color-primary-light: #1ebbff;
-  --color-primary-lighter: #9ce1ff;
-  --color-primary-dark: #0080b7;
-  --color-primary-darker: #006089;
-  --color-text-body: #00202e;
-  --color-text-body-lighter: #006089;
-  --color-text-heading: #006089;
-  --color-text-white: #ffffff;
-  --color-warning-default: #d80f0f;
-  --color-link: #005f89;
-  --color-link-hover: #00202e;
-  --color-black: #000000;
-  --color-white: #ffffff;
-  --color-emulsify-blue-100: #e6f5fc;
-  --color-emulsify-blue-200: #ccecfa;
-  --color-emulsify-blue-300: #99d9f4;
-  --color-emulsify-blue-400: #66c5ef;
-  --color-emulsify-blue-500: #33b2e9;
-  --color-emulsify-blue-600: #009fe4;
-  --color-emulsify-blue-700: #007fb6;
-  --color-emulsify-blue-800: #005f89;
-  --color-emulsify-blue-900: #00405b;
-  --color-emulsify-blue-1000: #00202e;
-  --color-grays-100: #eaebec;
-  --color-grays-200: #d4d7d8;
-  --color-grays-300: #a9afb1;
-  --color-grays-400: #7f878b;
-  --color-grays-500: #545f64;
-  --color-grays-600: #29373d;
-  --color-grays-700: #212c31;
-  --color-grays-800: #192125;
-  --color-grays-900: #101618;
-  --color-grays-1000: #080b0c;
   --font-family-body: Inter;
   --font-family-heading: Inter;
   --spacing-xs: 0.125rem;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jun 2024 20:33:46 GMT
+ * Generated on Fri, 14 Jun 2024 20:51:41 GMT
  */
 
 :root {
@@ -117,12 +117,12 @@
   --checkbox-button-stroke-disabled: #a9afb1;
   --checkbox-spacing-gap: 0.25rem;
   --card-spacing: 1rem;
-  --button-color-bkg: #009fe4;
+  --button-color-bkg: #007fb6;
   --button-color-label: #ffffff;
-  --button-color-bkg-hover: #0080b7;
+  --button-color-bkg-hover: #005f89;
   --button-color-label-hover: #ffffff;
   --button-color-label-focus: #ffffff;
-  --button-color-bkg-focus: #0080b7;
+  --button-color-bkg-focus: #005f89;
   --button-padding-x: 1rem;
   --button-padding-x-hover: 1rem;
   --button-padding-x-focus: 1rem;
@@ -137,9 +137,9 @@
   --button-border-width-border-hover: 1px;
   --button-border-width-border-focus: 1px;
   --button-text-case: uppercase;
-  --button-border-color: #009fe4;
-  --button-border-color-hover: #0080b7;
-  --button-border-color-focus: #0080b7;
+  --button-border-color: #007fb6;
+  --button-border-color-hover: #005f89;
+  --button-border-color-focus: #005f89;
   --button-font-weight-label: Bold;
   --breadcrumb-default: [object Object];
   --breadcrumb-text-default: #545f64;
@@ -164,6 +164,8 @@
   --color-warning-default: #d80f0f;
   --color-link: #009fe4;
   --color-link-hover: #007fb6;
+  --color-button: #007fb6;
+  --color-button-hover: #005f89;
   --color-black: #000000;
   --color-white: #ffffff;
   --color-emulsify-blue-100: #e6f5fc;

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 10 May 2024 20:51:02 GMT
+ * Generated on Fri, 14 Jun 2024 20:33:46 GMT
  */
 
 :root {
@@ -142,7 +142,7 @@
   --button-border-color-focus: #0080b7;
   --button-font-weight-label: Bold;
   --breadcrumb-default: [object Object];
-  --breadcrumb-text-default: #7f878b;
+  --breadcrumb-text-default: #545f64;
   --breadcrumb-text-hover: #192125;
   --block-quote-padding-x: 2rem;
   --block-quote-padding-y: 0.5rem;
@@ -150,7 +150,7 @@
   --accordion-p: [object Object];
   --accordion-color-body: #00202e;
   --accordion-color-header: #006089;
-  --accordion-color-header-hover: #009fe4;
+  --accordion-color-header-hover: #007fb6;
   --accordion-divider-color: #545f64;
   --color-primary-default: #009fe4;
   --color-primary-light: #1ebbff;

--- a/src/stylesheets/mixins.scss
+++ b/src/stylesheets/mixins.scss
@@ -62,7 +62,7 @@ $outer-container-break: var(--breakpoint-sm);
   $color-link: inherit,
   $color-link-hover: inherit,
   $font-weight: 700,
-  $margin: var(--spacing-xxl) 0 var(--spacing-lg)) {
+  $margin: var(--spacing-2xl) 0 var(--spacing-lg)) {
   color: $color;
   font-family: $font-family;
   font-weight: $font-weight;
@@ -88,7 +88,7 @@ $outer-container-break: var(--breakpoint-sm);
   $color-link: inherit,
   $color-link-hover: inherit,
   $font-weight: 700,
-  $margin: var(--spacing-xxl) 0 var(--spacing-lg)) {
+  $margin: var(--spacing-2xl) 0 var(--spacing-lg)) {
   color: $color;
   font-family: $font-family;
   font-weight: $font-weight;
@@ -114,7 +114,7 @@ $outer-container-break: var(--breakpoint-sm);
   $color-link: inherit,
   $color-link-hover: inherit,
   $font-weight: 700,
-  $margin: var(--spacing-xxl) 0 var(--spacing-lg)) {
+  $margin: var(--spacing-2xl) 0 var(--spacing-lg)) {
   color: $color;
   font-family: $font-family;
   font-weight: $font-weight;
@@ -140,7 +140,7 @@ $outer-container-break: var(--breakpoint-sm);
   $color-link: inherit,
   $color-link-hover: inherit,
   $font-weight: 600,
-  $margin: var(--spacing-xxl) 0 var(--spacing-lg)) {
+  $margin: var(--spacing-2xl) 0 var(--spacing-lg)) {
   color: $color;
   font-family: $font-family;
   font-weight: $font-weight;
@@ -166,7 +166,7 @@ $outer-container-break: var(--breakpoint-sm);
   $color-link: inherit,
   $color-link-hover: inherit,
   $font-weight: 600,
-  $margin: var(--spacing-xxl) 0 var(--spacing-lg)) {
+  $margin: var(--spacing-2xl) 0 var(--spacing-lg)) {
   color: $color;
   font-family: $font-family;
   font-weight: $font-weight;

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1580,16 +1580,16 @@
       "spacing": {
         "value": "{spacing.lg}",
         "type": "spacing"
-      }
-    },
-    "color": {
-      "heading": {
-        "value": "{color.primary.dark}",
-        "type": "color"
       },
-      "subheading": {
-        "value": "{color.primary.darker}",
-        "type": "color"
+      "color": {
+        "heading": {
+          "value": "{color.primary.dark}",
+          "type": "color"
+        },
+        "subheading": {
+          "value": "{color.primary.darker}",
+          "type": "color"
+        }
       }
     }
   },

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1581,6 +1581,16 @@
         "value": "{spacing.lg}",
         "type": "spacing"
       }
+    },
+    "color": {
+      "heading": {
+        "value": "{color.primary.dark}",
+        "type": "color"
+      },
+      "subheading": {
+        "value": "{color.primary.darker}",
+        "type": "color"
+      }
     }
   },
   "components/checkbox": {

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1411,7 +1411,7 @@
           "type": "color"
         },
         "header-hover": {
-          "value": "{color.link}",
+          "value": "{color.link-hover}",
           "type": "color"
         }
       },
@@ -1451,7 +1451,7 @@
       },
       "text": {
         "default": {
-          "value": "{color.grays.400}",
+          "value": "{color.grays.500}",
           "type": "color"
         },
         "hover": {

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1367,6 +1367,14 @@
       "link-hover": {
         "value": "{color.EmulsifyBlue.700}",
         "type": "color"
+      },
+      "button": {
+        "value": "{color.EmulsifyBlue.700}",
+        "type": "color"
+      },
+      "button-hover": {
+        "value": "{color.EmulsifyBlue.800}",
+        "type": "color"
       }
     },
     "fontFamily": {
@@ -1465,7 +1473,7 @@
     "button": {
       "color": {
         "bkg": {
-          "value": "{color.primary.default}",
+          "value": "{color.button}",
           "type": "color",
           "focus": {
             "value": "red",
@@ -1477,7 +1485,7 @@
           "type": "color"
         },
         "bkg-hover": {
-          "value": "{color.primary.dark}",
+          "value": "{color.button-hover}",
           "type": "color"
         },
         "label-hover": {
@@ -1489,7 +1497,7 @@
           "type": "color"
         },
         "bkg-focus": {
-          "value": "{color.primary.dark}",
+          "value": "{color.button-hover}",
           "type": "color"
         }
       },

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -2099,7 +2099,7 @@
             "type": "color"
           },
           "icon": {
-            "value": "{color.bkg}",
+            "value": "{color.link}",
             "type": "color"
           }
         },

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1885,13 +1885,13 @@
             "type": "color"
           },
           "focus": {
-            "value": "{color.EmulsifyBlue.600}",
+            "value": "{color.primary.dark}",
             "type": "color"
           }
         },
         "fill": {
           "hover": {
-            "value": "{color.primary.default}",
+            "value": "{color.primary.dark}",
             "type": "color"
           }
         }

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1361,19 +1361,11 @@
         }
       },
       "link": {
-        "value": "{color.EmulsifyBlue.600}",
+        "value": "{color.EmulsifyBlue.800}",
         "type": "color"
       },
       "link-hover": {
-        "value": "{color.EmulsifyBlue.700}",
-        "type": "color"
-      },
-      "button": {
-        "value": "{color.EmulsifyBlue.700}",
-        "type": "color"
-      },
-      "button-hover": {
-        "value": "{color.EmulsifyBlue.800}",
+        "value": "{color.EmulsifyBlue.1000}",
         "type": "color"
       }
     },
@@ -1473,7 +1465,7 @@
     "button": {
       "color": {
         "bkg": {
-          "value": "{color.button}",
+          "value": "{color.primary.dark}",
           "type": "color",
           "focus": {
             "value": "red",
@@ -1485,7 +1477,7 @@
           "type": "color"
         },
         "bkg-hover": {
-          "value": "{color.button-hover}",
+          "value": "{color.primary.darker}",
           "type": "color"
         },
         "label-hover": {
@@ -1497,7 +1489,7 @@
           "type": "color"
         },
         "bkg-focus": {
-          "value": "{color.button-hover}",
+          "value": "{color.primary.darker}",
           "type": "color"
         }
       },
@@ -1803,11 +1795,11 @@
     "link": {
       "color": {
         "default": {
-          "value": "{color.EmulsifyBlue.600}",
+          "value": "{color.link}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.EmulsifyBlue.800}",
+          "value": "{color.link-hover}",
           "type": "color"
         }
       },

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -1367,6 +1367,10 @@
       "link-hover": {
         "value": "{color.EmulsifyBlue.1000}",
         "type": "color"
+      },
+      "table": {
+        "value": "{color.EmulsifyBlue.700}",
+        "type": "color"
       }
     },
     "fontFamily": {
@@ -2095,13 +2099,13 @@
             "type": "color"
           },
           "icon": {
-            "value": "{color.EmulsifyBlue.700}",
+            "value": "{color.table}",
             "type": "color"
           }
         },
         "header": {
           "bg": {
-            "value": "{color.primary.default}",
+            "value": "{color.table}",
             "type": "color"
           },
           "text": {

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -63,7 +63,7 @@
           "type": "color"
         },
         "hover": {
-          "value": "#009fe4",
+          "value": "#005f89",
           "type": "color"
         }
       },
@@ -370,11 +370,11 @@
   "link": {
     "color": {
       "default": {
-        "value": "#009fe4",
+        "value": "#005f89",
         "type": "color"
       },
       "hover": {
-        "value": "#005f89",
+        "value": "#00202e",
         "type": "color"
       }
     },
@@ -611,7 +611,7 @@
   "button": {
     "color": {
       "bkg": {
-        "value": "#007fb6",
+        "value": "#0080b7",
         "type": "color",
         "focus": {
           "value": "red",
@@ -623,7 +623,7 @@
         "type": "color"
       },
       "bkg-hover": {
-        "value": "#005f89",
+        "value": "#006089",
         "type": "color"
       },
       "label-hover": {
@@ -635,7 +635,7 @@
         "type": "color"
       },
       "bkg-focus": {
-        "value": "#005f89",
+        "value": "#006089",
         "type": "color"
       }
     },
@@ -701,15 +701,15 @@
     },
     "border": {
       "color": {
-        "value": "#007fb6",
+        "value": "#0080b7",
         "type": "color"
       },
       "color-hover": {
-        "value": "#005f89",
+        "value": "#006089",
         "type": "color"
       },
       "color-focus": {
-        "value": "#005f89",
+        "value": "#006089",
         "type": "color"
       }
     },
@@ -784,7 +784,7 @@
         "type": "color"
       },
       "header-hover": {
-        "value": "#007fb6",
+        "value": "#00202e",
         "type": "color"
       }
     },
@@ -845,19 +845,11 @@
       }
     },
     "link": {
-      "value": "#009fe4",
+      "value": "#005f89",
       "type": "color"
     },
     "link-hover": {
-      "value": "#007fb6",
-      "type": "color"
-    },
-    "button": {
-      "value": "#007fb6",
-      "type": "color"
-    },
-    "button-hover": {
-      "value": "#005f89",
+      "value": "#00202e",
       "type": "color"
     },
     "black": {

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -733,7 +733,7 @@
     },
     "text": {
       "default": {
-        "value": "#7f878b",
+        "value": "#545f64",
         "type": "color"
       },
       "hover": {
@@ -784,7 +784,7 @@
         "type": "color"
       },
       "header-hover": {
-        "value": "#009fe4",
+        "value": "#007fb6",
         "type": "color"
       }
     },

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -275,13 +275,13 @@
           "type": "color"
         },
         "focus": {
-          "value": "#009fe4",
+          "value": "#0080b7",
           "type": "color"
         }
       },
       "fill": {
         "hover": {
-          "value": "#009fe4",
+          "value": "#0080b7",
           "type": "color"
         }
       }

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -606,162 +606,14 @@
     "spacing": {
       "value": 16,
       "type": "spacing"
-    }
-  },
-  "color": {
-    "heading": {
-      "value": "#0080b7",
-      "type": "color"
     },
-    "subheading": {
-      "value": "#006089",
-      "type": "color"
-    },
-    "primary": {
-      "default": {
-        "value": "#009fe4",
-        "type": "color",
-        "description": "600"
-      },
-      "light": {
-        "value": "#1ebbff",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "#9ce1ff",
-        "type": "color"
-      },
-      "dark": {
+    "color": {
+      "heading": {
         "value": "#0080b7",
         "type": "color"
       },
-      "darker": {
+      "subheading": {
         "value": "#006089",
-        "type": "color"
-      }
-    },
-    "text": {
-      "body": {
-        "value": "#00202e",
-        "type": "color"
-      },
-      "body-lighter": {
-        "value": "#006089",
-        "type": "color"
-      },
-      "heading": {
-        "value": "#006089",
-        "type": "color",
-        "description": "{color.primary.dark}"
-      },
-      "white": {
-        "value": "#ffffff",
-        "type": "color"
-      }
-    },
-    "warning": {
-      "default": {
-        "value": "#D80F0F",
-        "type": "color"
-      }
-    },
-    "link": {
-      "value": "#005f89",
-      "type": "color"
-    },
-    "link-hover": {
-      "value": "#00202e",
-      "type": "color"
-    },
-    "black": {
-      "value": "#000000",
-      "type": "color"
-    },
-    "white": {
-      "value": "#ffffff",
-      "type": "color"
-    },
-    "EmulsifyBlue": {
-      "100": {
-        "value": "#e6f5fc",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ccecfa",
-        "type": "color"
-      },
-      "300": {
-        "value": "#99d9f4",
-        "type": "color"
-      },
-      "400": {
-        "value": "#66c5ef",
-        "type": "color"
-      },
-      "500": {
-        "value": "#33b2e9",
-        "type": "color"
-      },
-      "600": {
-        "value": "#009fe4",
-        "type": "color"
-      },
-      "700": {
-        "value": "#007fb6",
-        "type": "color"
-      },
-      "800": {
-        "value": "#005f89",
-        "type": "color"
-      },
-      "900": {
-        "value": "#00405b",
-        "type": "color"
-      },
-      "1000": {
-        "value": "#00202e",
-        "type": "color"
-      }
-    },
-    "grays": {
-      "100": {
-        "value": "#eaebec",
-        "type": "color"
-      },
-      "200": {
-        "value": "#d4d7d8",
-        "type": "color"
-      },
-      "300": {
-        "value": "#a9afb1",
-        "type": "color"
-      },
-      "400": {
-        "value": "#7f878b",
-        "type": "color"
-      },
-      "500": {
-        "value": "#545f64",
-        "type": "color"
-      },
-      "600": {
-        "value": "#29373d",
-        "type": "color"
-      },
-      "700": {
-        "value": "#212c31",
-        "type": "color"
-      },
-      "800": {
-        "value": "#192125",
-        "type": "color"
-      },
-      "900": {
-        "value": "#101618",
-        "type": "color"
-      },
-      "1000": {
-        "value": "#080b0c",
         "type": "color"
       }
     }
@@ -949,6 +801,156 @@
     "divider": {
       "color": {
         "value": "#545f64",
+        "type": "color"
+      }
+    }
+  },
+  "color": {
+    "primary": {
+      "default": {
+        "value": "#009fe4",
+        "type": "color",
+        "description": "600"
+      },
+      "light": {
+        "value": "#1ebbff",
+        "type": "color"
+      },
+      "lighter": {
+        "value": "#9ce1ff",
+        "type": "color"
+      },
+      "dark": {
+        "value": "#0080b7",
+        "type": "color"
+      },
+      "darker": {
+        "value": "#006089",
+        "type": "color"
+      }
+    },
+    "text": {
+      "body": {
+        "value": "#00202e",
+        "type": "color"
+      },
+      "body-lighter": {
+        "value": "#006089",
+        "type": "color"
+      },
+      "heading": {
+        "value": "#006089",
+        "type": "color",
+        "description": "{color.primary.dark}"
+      },
+      "white": {
+        "value": "#ffffff",
+        "type": "color"
+      }
+    },
+    "warning": {
+      "default": {
+        "value": "#D80F0F",
+        "type": "color"
+      }
+    },
+    "link": {
+      "value": "#005f89",
+      "type": "color"
+    },
+    "link-hover": {
+      "value": "#00202e",
+      "type": "color"
+    },
+    "black": {
+      "value": "#000000",
+      "type": "color"
+    },
+    "white": {
+      "value": "#ffffff",
+      "type": "color"
+    },
+    "EmulsifyBlue": {
+      "100": {
+        "value": "#e6f5fc",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ccecfa",
+        "type": "color"
+      },
+      "300": {
+        "value": "#99d9f4",
+        "type": "color"
+      },
+      "400": {
+        "value": "#66c5ef",
+        "type": "color"
+      },
+      "500": {
+        "value": "#33b2e9",
+        "type": "color"
+      },
+      "600": {
+        "value": "#009fe4",
+        "type": "color"
+      },
+      "700": {
+        "value": "#007fb6",
+        "type": "color"
+      },
+      "800": {
+        "value": "#005f89",
+        "type": "color"
+      },
+      "900": {
+        "value": "#00405b",
+        "type": "color"
+      },
+      "1000": {
+        "value": "#00202e",
+        "type": "color"
+      }
+    },
+    "grays": {
+      "100": {
+        "value": "#eaebec",
+        "type": "color"
+      },
+      "200": {
+        "value": "#d4d7d8",
+        "type": "color"
+      },
+      "300": {
+        "value": "#a9afb1",
+        "type": "color"
+      },
+      "400": {
+        "value": "#7f878b",
+        "type": "color"
+      },
+      "500": {
+        "value": "#545f64",
+        "type": "color"
+      },
+      "600": {
+        "value": "#29373d",
+        "type": "color"
+      },
+      "700": {
+        "value": "#212c31",
+        "type": "color"
+      },
+      "800": {
+        "value": "#192125",
+        "type": "color"
+      },
+      "900": {
+        "value": "#101618",
+        "type": "color"
+      },
+      "1000": {
+        "value": "#080b0c",
         "type": "color"
       }
     }

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -621,7 +621,7 @@
   "button": {
     "color": {
       "bkg": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color",
         "focus": {
           "value": "red",
@@ -633,7 +633,7 @@
         "type": "color"
       },
       "bkg-hover": {
-        "value": "#006089",
+        "value": "#00405b",
         "type": "color"
       },
       "label-hover": {
@@ -645,7 +645,7 @@
         "type": "color"
       },
       "bkg-focus": {
-        "value": "#006089",
+        "value": "#00405b",
         "type": "color"
       }
     },
@@ -711,15 +711,15 @@
     },
     "border": {
       "color": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color"
       },
       "color-hover": {
-        "value": "#006089",
+        "value": "#00405b",
         "type": "color"
       },
       "color-focus": {
-        "value": "#006089",
+        "value": "#00405b",
         "type": "color"
       }
     },
@@ -862,8 +862,8 @@
       "value": "#00202e",
       "type": "color"
     },
-    "table": {
-      "value": "#005f89",
+    "link-hover-lighter": {
+      "value": "#00405b",
       "type": "color"
     },
     "black": {
@@ -2555,7 +2555,6 @@
       "color.text.heading": "4f236039ebbe9ab9f7b2fc9c730fd1e03d770646",
       "color.warning.default": "53587ede6f97488b7db21986db7147e7886f42b3",
       "color.link": "1f637c9a615fd4d0f936c62a2fadea575f6cc398",
-      "color.link-hover": "74d0f74b830a9dd07279967cea7c9f662178e310",
       "color.black": "55dac975a4f6f9c054d53b85f7ffba4a1d27f291",
       "color.white": "f0dddd77af08dcb4d16939df6ea9a1a24129780f",
       "color.EmulsifyBlue.100": "e83fe29a796a479f9b6331c27c44497ba7db917a",
@@ -2636,7 +2635,8 @@
       "border.lg": "d98fd94c338de18d8949d1bb0b4767131646a4e1",
       "checkbox.spacing.gap": "59fbad63c0994ee956f8790e994534f9f5f5e922",
       "checkbox.color.label": "4db65c0b61319b6c85cdb9c1b683d84e2f65ff52",
-      "checkbox.color.label-disabled": "3a5dec39f06f92904d80c2096f9c439ae0b5d09a"
+      "checkbox.color.label-disabled": "3a5dec39f06f92904d80c2096f9c439ae0b5d09a",
+      "color.link-hover": "74d0f74b830a9dd07279967cea7c9f662178e310"
     },
     "type": "other",
     "value": "[object Object]"

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -611,7 +611,7 @@
   "button": {
     "color": {
       "bkg": {
-        "value": "#009fe4",
+        "value": "#007fb6",
         "type": "color",
         "focus": {
           "value": "red",
@@ -623,7 +623,7 @@
         "type": "color"
       },
       "bkg-hover": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color"
       },
       "label-hover": {
@@ -635,7 +635,7 @@
         "type": "color"
       },
       "bkg-focus": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color"
       }
     },
@@ -701,15 +701,15 @@
     },
     "border": {
       "color": {
-        "value": "#009fe4",
+        "value": "#007fb6",
         "type": "color"
       },
       "color-hover": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color"
       },
       "color-focus": {
-        "value": "#0080b7",
+        "value": "#005f89",
         "type": "color"
       }
     },
@@ -850,6 +850,14 @@
     },
     "link-hover": {
       "value": "#007fb6",
+      "type": "color"
+    },
+    "button": {
+      "value": "#007fb6",
+      "type": "color"
+    },
+    "button-hover": {
+      "value": "#005f89",
       "type": "color"
     },
     "black": {

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -608,6 +608,164 @@
       "type": "spacing"
     }
   },
+  "color": {
+    "heading": {
+      "value": "#0080b7",
+      "type": "color"
+    },
+    "subheading": {
+      "value": "#006089",
+      "type": "color"
+    },
+    "primary": {
+      "default": {
+        "value": "#009fe4",
+        "type": "color",
+        "description": "600"
+      },
+      "light": {
+        "value": "#1ebbff",
+        "type": "color"
+      },
+      "lighter": {
+        "value": "#9ce1ff",
+        "type": "color"
+      },
+      "dark": {
+        "value": "#0080b7",
+        "type": "color"
+      },
+      "darker": {
+        "value": "#006089",
+        "type": "color"
+      }
+    },
+    "text": {
+      "body": {
+        "value": "#00202e",
+        "type": "color"
+      },
+      "body-lighter": {
+        "value": "#006089",
+        "type": "color"
+      },
+      "heading": {
+        "value": "#006089",
+        "type": "color",
+        "description": "{color.primary.dark}"
+      },
+      "white": {
+        "value": "#ffffff",
+        "type": "color"
+      }
+    },
+    "warning": {
+      "default": {
+        "value": "#D80F0F",
+        "type": "color"
+      }
+    },
+    "link": {
+      "value": "#005f89",
+      "type": "color"
+    },
+    "link-hover": {
+      "value": "#00202e",
+      "type": "color"
+    },
+    "black": {
+      "value": "#000000",
+      "type": "color"
+    },
+    "white": {
+      "value": "#ffffff",
+      "type": "color"
+    },
+    "EmulsifyBlue": {
+      "100": {
+        "value": "#e6f5fc",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ccecfa",
+        "type": "color"
+      },
+      "300": {
+        "value": "#99d9f4",
+        "type": "color"
+      },
+      "400": {
+        "value": "#66c5ef",
+        "type": "color"
+      },
+      "500": {
+        "value": "#33b2e9",
+        "type": "color"
+      },
+      "600": {
+        "value": "#009fe4",
+        "type": "color"
+      },
+      "700": {
+        "value": "#007fb6",
+        "type": "color"
+      },
+      "800": {
+        "value": "#005f89",
+        "type": "color"
+      },
+      "900": {
+        "value": "#00405b",
+        "type": "color"
+      },
+      "1000": {
+        "value": "#00202e",
+        "type": "color"
+      }
+    },
+    "grays": {
+      "100": {
+        "value": "#eaebec",
+        "type": "color"
+      },
+      "200": {
+        "value": "#d4d7d8",
+        "type": "color"
+      },
+      "300": {
+        "value": "#a9afb1",
+        "type": "color"
+      },
+      "400": {
+        "value": "#7f878b",
+        "type": "color"
+      },
+      "500": {
+        "value": "#545f64",
+        "type": "color"
+      },
+      "600": {
+        "value": "#29373d",
+        "type": "color"
+      },
+      "700": {
+        "value": "#212c31",
+        "type": "color"
+      },
+      "800": {
+        "value": "#192125",
+        "type": "color"
+      },
+      "900": {
+        "value": "#101618",
+        "type": "color"
+      },
+      "1000": {
+        "value": "#080b0c",
+        "type": "color"
+      }
+    }
+  },
   "button": {
     "color": {
       "bkg": {
@@ -791,156 +949,6 @@
     "divider": {
       "color": {
         "value": "#545f64",
-        "type": "color"
-      }
-    }
-  },
-  "color": {
-    "primary": {
-      "default": {
-        "value": "#009fe4",
-        "type": "color",
-        "description": "600"
-      },
-      "light": {
-        "value": "#1ebbff",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "#9ce1ff",
-        "type": "color"
-      },
-      "dark": {
-        "value": "#0080b7",
-        "type": "color"
-      },
-      "darker": {
-        "value": "#006089",
-        "type": "color"
-      }
-    },
-    "text": {
-      "body": {
-        "value": "#00202e",
-        "type": "color"
-      },
-      "body-lighter": {
-        "value": "#006089",
-        "type": "color"
-      },
-      "heading": {
-        "value": "#006089",
-        "type": "color",
-        "description": "{color.primary.dark}"
-      },
-      "white": {
-        "value": "#ffffff",
-        "type": "color"
-      }
-    },
-    "warning": {
-      "default": {
-        "value": "#D80F0F",
-        "type": "color"
-      }
-    },
-    "link": {
-      "value": "#005f89",
-      "type": "color"
-    },
-    "link-hover": {
-      "value": "#00202e",
-      "type": "color"
-    },
-    "black": {
-      "value": "#000000",
-      "type": "color"
-    },
-    "white": {
-      "value": "#ffffff",
-      "type": "color"
-    },
-    "EmulsifyBlue": {
-      "100": {
-        "value": "#e6f5fc",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ccecfa",
-        "type": "color"
-      },
-      "300": {
-        "value": "#99d9f4",
-        "type": "color"
-      },
-      "400": {
-        "value": "#66c5ef",
-        "type": "color"
-      },
-      "500": {
-        "value": "#33b2e9",
-        "type": "color"
-      },
-      "600": {
-        "value": "#009fe4",
-        "type": "color"
-      },
-      "700": {
-        "value": "#007fb6",
-        "type": "color"
-      },
-      "800": {
-        "value": "#005f89",
-        "type": "color"
-      },
-      "900": {
-        "value": "#00405b",
-        "type": "color"
-      },
-      "1000": {
-        "value": "#00202e",
-        "type": "color"
-      }
-    },
-    "grays": {
-      "100": {
-        "value": "#eaebec",
-        "type": "color"
-      },
-      "200": {
-        "value": "#d4d7d8",
-        "type": "color"
-      },
-      "300": {
-        "value": "#a9afb1",
-        "type": "color"
-      },
-      "400": {
-        "value": "#7f878b",
-        "type": "color"
-      },
-      "500": {
-        "value": "#545f64",
-        "type": "color"
-      },
-      "600": {
-        "value": "#29373d",
-        "type": "color"
-      },
-      "700": {
-        "value": "#212c31",
-        "type": "color"
-      },
-      "800": {
-        "value": "#192125",
-        "type": "color"
-      },
-      "900": {
-        "value": "#101618",
-        "type": "color"
-      },
-      "1000": {
-        "value": "#080b0c",
         "type": "color"
       }
     }

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -107,7 +107,7 @@
       },
       "header": {
         "bg": {
-          "value": "#009fe4",
+          "value": "#007fb6",
           "type": "color"
         },
         "text": {
@@ -860,6 +860,10 @@
     },
     "link-hover": {
       "value": "#00202e",
+      "type": "color"
+    },
+    "table": {
+      "value": "#007fb6",
       "type": "color"
     },
     "black": {


### PR DESCRIPTION
## Summary

This PR fixes color contrast for some components to meet WCAG AA Standard

## How to review this pull request
- [x] Visit the following components in Storybook and note the Accessibility tab. 

- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-button--button
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-cards--card-horizontal
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-cards--card-vertical
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-menus--breadcrumbs
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-menus--inline
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-menus--social
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-typography--headings
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-typography-links--links
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-typography--tables
- [x]     https://deploy-preview-126--emulsify-ui-kit.netlify.app/?path=/story/components-pager--basic

- [x] Confirm there aren't color contrast issues anymore and they look like the design on [Figma](https://www.figma.com/design/TuQAuw81mBRsaepz2HP7BX/Emulsify-UI-Kit?node-id=23749-10550&t=WrjXhIBbN4skRrS0-4)... I had to do some changes there. However, I saved a backup just in case we don't want those colors used.

## Closing issues

Closes #113
