### PR TITLE
Fix the Emulsify logo src

### DIFF
--- a/.storybook/emulsifyTheme.js
+++ b/.storybook/emulsifyTheme.js
@@ -35,6 +35,6 @@ export default create({
   brandTitle: 'Emulsify',
   brandUrl: 'https://emulsify.info',
   brandImage:
-    'https://raw.githubusercontent.com/emulsify-ds/emulsify-ui-kit/storybook-theming/images/emulsify-logo-sb.svg',
+    'https://raw.githubusercontent.com/emulsify-ds/emulsify-ui-kit/main/src/images/logo.svg',
   brandTarget: '_self',
 });

--- a/src/components/tokens/_tokens.scss
+++ b/src/components/tokens/_tokens.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 17 Jun 2024 23:59:55 GMT
+ * Generated on Mon, 22 Jul 2024 17:58:36 GMT
  */
 
 :root {


### PR DESCRIPTION
## Summary

This PR fixes the src of the Emulsify logo inside of Storybook's sidebar so it is no longer a broken link.

## Documentation update (required)

No document changes required.

## How to review this pull request

- [ ] Run `npm run develop` and confirm the Emulsify logo shows inside of Storybook's sidebar.