### PR TITLE
 EMULSIF-236: Convert Images to support SDC

### DIFF
--- a/src/components/images/image/figure.component.yml
+++ b/src/components/images/image/figure.component.yml
@@ -1,0 +1,36 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/10.1.x/core/modules/sdc/src/metadata.schema.json
+
+name: Figure
+group: Components
+status: stable
+props:
+  type: object
+  required:
+    - image_src
+    - image_alt
+  properties:
+    output_image_tag:
+      type: boolean
+      title: Output image tag
+      description: Specifies whether to output the image tag
+      data: true
+    image_url:
+      type: string
+      title: Image URL
+      description: 'Specifies the URL that the image links to'
+      data: '#'
+    image_src:
+      type: string
+      title: Source
+      description: 'Specifies the path to the image'
+      data: 'https://placehold.co/1200x600'
+    image_alt:
+      type: string
+      title: Alternate text
+      description: 'Specifies an alternate text for the image'
+      data: 'This is the alt text'
+    image_caption:
+      type: string
+      title: Image caption
+      description: 'Specifies the caption for the image'
+      data: 'This is an image caption.'

--- a/src/components/images/image/figure.yml
+++ b/src/components/images/image/figure.yml
@@ -1,5 +1,0 @@
-output_image_tag: true
-image_url: '#'
-image_src: 'https://placehold.co/1200x600'
-image_alt: 'This is the alt text'
-image_caption: 'This is an image caption.'

--- a/src/components/images/image/image.component.yml
+++ b/src/components/images/image/image.component.yml
@@ -1,0 +1,36 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/10.1.x/core/modules/sdc/src/metadata.schema.json
+
+name: Image
+group: Components
+status: stable
+props:
+  type: object
+  required:
+    - image_src
+    - image_alt
+  properties:
+    output_image_tag:
+      type: boolean
+      title: Output image tag
+      description: Specifies whether to output the image tag
+      data: true
+    image_src:
+      type: string
+      title: Source
+      description: 'Specifies the path to the image'
+      data: 'https://placehold.co/320x180'
+    image_alt:
+      type: string
+      title: Alternate text
+      description: 'Specifies an alternate text for the image'
+      data: 'A 16 by 9 image'
+    image_srcset:
+      type: string
+      title: Source Set Attribute
+      description: The image's srcset attribute, which defines multiple image sources for different device resolutions.
+      data: 'https://placehold.co/320x180 320w, https://placehold.co/480x270 480w, https://placehold.co/640x360 640w, https://placehold.co/800x450 800w, https://placehold.co/960x540 960w, https://placehold.co/1120x630 1120w, https://placehold.co/1280x720 1280w, https://placehold.co/1440x810 1440w, https://placehold.co/1600x900 1600w, https://placehold.co/1760x990 1760w, https://placehold.co/1920x1080 1920w, https://placehold.co/2080x1170 2080w, https://placehold.co/2240x1260 2240w'
+    image_sizes:
+      type: string
+      title: Image sizes
+      description: 'Specifies the intended display sizes of the image'
+      data: '100vw'

--- a/src/components/images/image/image.yml
+++ b/src/components/images/image/image.yml
@@ -1,5 +1,0 @@
-output_image_tag: true
-image_srcset: 'https://placehold.co/320x180 320w, https://placehold.co/480x270 480w, https://placehold.co/640x360 640w, https://placehold.co/800x450 800w, https://placehold.co/960x540 960w, https://placehold.co/1120x630 1120w, https://placehold.co/1280x720 1280w, https://placehold.co/1440x810 1440w, https://placehold.co/1600x900 1600w, https://placehold.co/1760x990 1760w, https://placehold.co/1920x1080 1920w, https://placehold.co/2080x1170 2080w, https://placehold.co/2240x1260 2240w'
-image_sizes: '100vw'
-image_src: 'https://placehold.co/320x180'
-image_alt: 'A 16 by 9 image'

--- a/src/components/images/images.stories.js
+++ b/src/components/images/images.stories.js
@@ -1,8 +1,10 @@
-import image from './image/responsive-image.twig';
-import figure from './image/figure.twig';
+import imageTwig from './image/responsive-image.twig';
+import figureTwig from './image/figure.twig';
 
-import imageData from './image/image.yml';
-import figureData from './image/figure.yml';
+import { props as imageProps } from './image/image.component.yml';
+import { props as figureProps } from './image/figure.component.yml';
+
+import { mapDataToTwig } from '../../util/dataTransformers';
 
 const svgIcons = require.context('../../../images/icons/', true, /\.svg$/);
 const icons = [];
@@ -11,11 +13,21 @@ svgIcons.keys().forEach((key) => {
   icons.push(icon);
 });
 
+const imageData = mapDataToTwig(imageProps.properties);
+const figureData = mapDataToTwig(figureProps.properties);
+
 /**
  * Storybook Definition.
  */
-export default { title: 'Components/Media' };
 
-export const images = () => image(imageData);
+export default {
+  title: 'Components/Media',
+  decorators: [
+    (story) =>
+      `<div style="max-width: 890px; margin: 0 auto;">${story()}</div>`,
+  ],
+};
 
-export const figures = () => figure(figureData);
+export const Image = () => imageTwig(imageData);
+
+export const Figure = () => figureTwig(figureData);

--- a/src/util/dataTransformers.js
+++ b/src/util/dataTransformers.js
@@ -1,0 +1,20 @@
+/**
+ * Maps properties from a given data object to a new object containing only the `data` values.
+ *
+ * This function iterates through the keys of the `props` object and extracts the `data` property
+ * from each key, if it exists. The result is a new object where each key has its corresponding `data` value.
+ *
+ * @param {Object} props - The object containing properties with `data` fields.
+ * @returns {Object} - A new object where each key is mapped to its `data` value from the original object.
+ */
+export function mapDataToTwig(props) {
+  const transformedData = {};
+
+  for (const key in props) {
+    if (props.hasOwnProperty(key) && props[key]?.data !== undefined) {
+      transformedData[key] = props[key].data;
+    }
+  }
+
+  return transformedData;
+}


### PR DESCRIPTION
## Ticket: [EMULSIF-236](https://app.clickup.com/t/36718269/EMULSIF-236)

## Summary
<!-- Summary of the PR -->

This PR updates the `yml`  file and `stories.js`  file of the `Images` component to meet the schema the Single Directory Component uses it

## How to review this pull request
* [ ] Run `npm run storybook`
* [ ] Go to http://localhost:6006/?path=/story/components-media--image and http://localhost:6006/?path=/story/components-media--figure
* [ ] Confirm the image and figure are still looking and working as expected