### PR TITLE
Add link color inverse and link color hover tokens

### DIFF
--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -2115,6 +2115,14 @@
         "hover": {
           "value": "{color.link-hover}",
           "type": "color"
+        },
+        "inverse": {
+          "value": "{color.text.white}",
+          "type": "color"
+        },
+        "inverse-hover": {
+          "value": "{color.primary.lighter}",
+          "type": "color"
         }
       },
       "body": {

--- a/src/tokens/figma.tokens.json
+++ b/src/tokens/figma.tokens.json
@@ -2778,8 +2778,7 @@
         "components/announcement": "enabled",
         "components/banner": "enabled",
         "components/footer": "enabled",
-        "components/header": "enabled",
-        "components/utilityMenu": "disabled"
+        "components/header": "enabled"
       },
       "$figmaCollectionId": "VariableCollectionId:23237:16908",
       "$figmaModeId": "23237:10",
@@ -2967,8 +2966,7 @@
       "name": "Emulsify Global",
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
-        "global": "enabled",
-        "components/utilityMenu": "disabled"
+        "global": "enabled"
       },
       "$figmaCollectionId": "VariableCollectionId:23237:17089",
       "$figmaModeId": "23237:11",
@@ -3020,8 +3018,7 @@
       "name": "Emulsify Semantic",
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
-        "semantic": "enabled",
-        "components/utilityMenu": "disabled"
+        "semantic": "enabled"
       },
       "$figmaCollectionId": "VariableCollectionId:23237:17133",
       "$figmaModeId": "23237:12",
@@ -3043,8 +3040,7 @@
       "name": "Emulsify Storybook only",
       "$figmaStyleReferences": {},
       "selectedTokenSets": {
-        "storybook": "source",
-        "components/utilityMenu": "disabled"
+        "storybook": "source"
       },
       "$figmaCollectionId": "VariableCollectionId:23237:17144",
       "$figmaModeId": "23237:13",
@@ -3072,8 +3068,7 @@
         "components/status": "enabled",
         "components/table": "enabled",
         "components/tabs": "enabled",
-        "components/textField": "enabled",
-        "components/utilityMenu": "disabled"
+        "components/textField": "enabled"
       },
       "$figmaCollectionId": "VariableCollectionId:23237:17145",
       "$figmaModeId": "23237:14",
@@ -3226,8 +3221,7 @@
         "components/table": "enabled",
         "components/tabs": "enabled",
         "components/textField": "enabled",
-        "semantic": "enabled",
-        "components/utilityMenu": "disabled"
+        "semantic": "enabled"
       },
       "group": "WUP"
     },
@@ -3254,8 +3248,7 @@
         "components/status": "enabled",
         "components/table": "enabled",
         "components/tabs": "enabled",
-        "components/textField": "enabled",
-        "components/utilityMenu": "disabled"
+        "components/textField": "enabled"
       },
       "group": "WUP"
     }

--- a/src/tokens/tokens.scss
+++ b/src/tokens/tokens.scss
@@ -79,6 +79,8 @@
   --main-menu-color-dropdown-label-hover: #006089;
   --link-color-default: #005f89;
   --link-color-hover: #00202e;
+  --link-color-inverse: #fff;
+  --link-color-inverse-hover: #9ce1ff;
   --link-body: [object Object];
   --input-gap: 0.5rem;
   --input-padding-x: 1rem;

--- a/src/tokens/transformed.tokens.json
+++ b/src/tokens/transformed.tokens.json
@@ -394,6 +394,14 @@
       "hover": {
         "value": "#00202e",
         "type": "color"
+      },
+      "inverse": {
+        "value": "#ffffff",
+        "type": "color"
+      },
+      "inverse-hover": {
+        "value": "#9ce1ff",
+        "type": "color"
       }
     },
     "body": {
@@ -2790,8 +2798,7 @@
       "components/announcement": "enabled",
       "components/banner": "enabled",
       "components/footer": "enabled",
-      "components/header": "enabled",
-      "components/utilityMenu": "disabled"
+      "components/header": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:23237:16908",
     "$figmaModeId": "23237:10",
@@ -2980,8 +2987,7 @@
     "id": "0a5c4562bd35f00ce8a339239980a3842147c0bd",
     "$figmaStyleReferences": {},
     "selectedTokenSets": {
-      "global": "enabled",
-      "components/utilityMenu": "disabled"
+      "global": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:23237:17089",
     "$figmaModeId": "23237:11",
@@ -3034,8 +3040,7 @@
     "id": "ca91148967a5dcc80f7e50f6ccfe35b30efd5f2f",
     "$figmaStyleReferences": {},
     "selectedTokenSets": {
-      "semantic": "enabled",
-      "components/utilityMenu": "disabled"
+      "semantic": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:23237:17133",
     "$figmaModeId": "23237:12",
@@ -3058,8 +3063,7 @@
     "id": "16a10d373d39988a75c7d612cd449a633f373c44",
     "$figmaStyleReferences": {},
     "selectedTokenSets": {
-      "storybook": "source",
-      "components/utilityMenu": "disabled"
+      "storybook": "source"
     },
     "$figmaCollectionId": "VariableCollectionId:23237:17144",
     "$figmaModeId": "23237:13",
@@ -3088,8 +3092,7 @@
       "components/status": "enabled",
       "components/table": "enabled",
       "components/tabs": "enabled",
-      "components/textField": "enabled",
-      "components/utilityMenu": "disabled"
+      "components/textField": "enabled"
     },
     "$figmaCollectionId": "VariableCollectionId:23237:17145",
     "$figmaModeId": "23237:14",
@@ -3243,8 +3246,7 @@
       "components/table": "enabled",
       "components/tabs": "enabled",
       "components/textField": "enabled",
-      "semantic": "enabled",
-      "components/utilityMenu": "disabled"
+      "semantic": "enabled"
     },
     "group": "WUP",
     "type": "other",
@@ -3272,8 +3274,7 @@
       "components/status": "enabled",
       "components/table": "enabled",
       "components/tabs": "enabled",
-      "components/textField": "enabled",
-      "components/utilityMenu": "disabled"
+      "components/textField": "enabled"
     },
     "group": "WUP",
     "type": "other",


### PR DESCRIPTION
This PR fixes missing tokens for link inverse and the hover state of it

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Verify there are new tokens for `--link-color-inverse: #fff;` and `--link-color-inverse-hover: #9ce1ff;`
