### PR TITLE
Fixes in contrast issue in secondary menu in main menu

### DIFF
--- a/src/components/navigation/main/_main-link.scss
+++ b/src/components/navigation/main/_main-link.scss
@@ -123,7 +123,7 @@
 .main-nav__link--level-1,
 .main-nav__link--level-2 {
   & {
-    font-size: var(--font-size-h6);
+    font-size: var(--font-size-body);
   }
 
   @include breakpoint('small-down') {


### PR DESCRIPTION
## Summary
This PR fixes the issue in the second row of the following [spreadsheet](https://docs.google.com/spreadsheets/d/1x5ADIN8wGSCnaDu4Qtc6M2ISvTAIwWyh/edit?usp=sharing&ouid=104946438556532889098&rtpof=true&sd=true)

I thought that we would need to update the color but by updating (in fact adding) a font-size of 18px, it meet's accessibility

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Please go to
- [ ] Compare it with what we have in [Figma](https://www.figma.com/design/TuQAuw81mBRsaepz2HP7BX/Emulsify-UI-Kit?node-id=23048-742&t=3mTvIfL86H5nyOzJ-4). I also updated the font size there
- [ ] The secondary menu (sub menu) should look the same and it should meet accessibility now since it's a large text. Check it out in this page https://webaim.org/resources/contrastchecker/