### PR TITLE
EMULSIF-442: Pager Accessibility Issue fixes

### DIFF
--- a/src/components/navigation/pager/pager.scss
+++ b/src/components/navigation/pager/pager.scss
@@ -28,7 +28,9 @@
   }
 
   &.is-active {
+    padding: 0.35rem 0.75rem;
     color: var(--pager-color-text-focus);
+    border: 2px solid var(--pager-color-fill-hover);
 
     &:hover,
     &:focus {

--- a/src/components/navigation/pager/pager.twig
+++ b/src/components/navigation/pager/pager.twig
@@ -67,11 +67,8 @@
         {% set current_class = current == key ? 'is-active' : '' %}
         {% set aria_current = current == key ? 'aria-current="page"' : '' %}
         <li {{ bem('item', [], pager__base_class, [current_class]) }}>
-          {% set title = current == key ? 'Current page'|t : 'Go to page @key'|t({'@key': key}) %}
-          <a {{ bem('link', [], pager__base_class, [current_class]) }} href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }} {{ aria_current }}>
-            <span {{ bem('visually-hidden') }}>
-              {{ current == key ? 'Current page'|t : 'Page '|t }}
-            </span>
+          {% set title = current != key ? 'title="Go to page @key"'|t({'@key': key}) : '' %}
+          <a {{ bem('link', [], pager__base_class, [current_class]) }} href="{{ item.href }}" {{ title }} {{ item.attributes|without('href', 'title') }} {{ aria_current }}>
             {{- key -}}
           </a>
         </li>

--- a/src/components/navigation/pager/pager.twig
+++ b/src/components/navigation/pager/pager.twig
@@ -60,14 +60,17 @@
       {% endif %}
       {# Add an ellipsis if there are further previous pages. #}
       {% if ellipses.previous %}
-        <li {{ bem('item', ['ellipsis'], pager__base_class) }} role="presentation">&hellip;</li>
+        <li {{ bem('item', ['ellipsis'], pager__base_class) }} role="presentation">
+          <span aria-hidden="true">&hellip;</span>
+          <span class="sr-only">Previous pages are hidden</span>
+        </li>
       {% endif %}
       {# Now generate the actual pager piece. #}
       {% for key, item in items.pages %}
         {% set current_class = current == key ? 'is-active' : '' %}
         {% set aria_current = current == key ? 'aria-current="page"' : '' %}
         <li {{ bem('item', [], pager__base_class, [current_class]) }}>
-          {% set title = current != key ? 'title="Go to page @key"'|t({'@key': key}) : '' %}
+          {% set title = current != key ? 'title="Go to page"' : '' %}
           <a {{ bem('link', [], pager__base_class, [current_class]) }} href="{{ item.href }}" {{ title }} {{ item.attributes|without('href', 'title') }} {{ aria_current }}>
             {{- key -}}
           </a>
@@ -75,7 +78,10 @@
       {% endfor %}
       {# Add an ellipsis if there are further next pages. #}
       {% if ellipses.next %}
-        <li {{ bem('item', ['ellipsis'], pager__base_class) }} role="presentation">&hellip;</li>
+        <li {{ bem('item', ['ellipsis'], pager__base_class) }} role="presentation">
+          <span aria-hidden="true">&hellip;</span>
+          <span class="sr-only">Next pages are hidden</span>
+        </li>
       {% endif %}
       {# Print next item if we are not on the last page. #}
       {% if items.next %}


### PR DESCRIPTION
## Tickets
[EMULSIF-442](https://fourkitchens.clickup.com/t/36718269/EMULSIF-442)
[EMULSIF-443](https://fourkitchens.clickup.com/t/36718269/EMULSIF-443)
[EMULSIF-461](https://fourkitchens.clickup.com/t/36718269/EMULSIF-461)

## Summary
- Reduce redundant usage of current page indication
- Add border indicator to current/active page since color can be an issue for color blindness users
- Add more context to ellipsis for screen readers, instead of "dot dot dot"
- Reduce redundant usage of "key" in "Go to page", the number page is already being announced

## How to review this pull request
- [x] Go to https://deploy-preview-173--emulsify-ui-kit.netlify.app/?path=/story/components-navigation-pager--with-first-and-last
- [x] By using a screen reader, start navigating with TAB key and reach the "10" link in the pagination
- [x] Confirm the word "current" is only announced once by the screen reader
- [x] Confirm the current/active page now have a border around it
- [x] Confirm the work "key" is not announced for the screen reader when you TAB to the next page (It should announce Go to page {number})
- [x] Confirm ellipsis are not being announced as "dot dot dot". They should give more context to the users
