### PR TITLE
Emulsif-440: Breadcrumb component does not follow established design pattern

### DIFF
--- a/src/components/navigation/base/_menu-item.twig
+++ b/src/components/navigation/base/_menu-item.twig
@@ -23,7 +23,7 @@
 {% endif %}
 
 {% set site_url = path("<current>") %}
-{% if site_url|render == item.url|render or item.is_active %}
+{% if site_url|render == item.url|render or item.is_active or item.url is empty %}
 	{% set link__attributes = link__attributes|merge({
     'aria-current': 'page',
   }) %}

--- a/src/components/navigation/base/menu.twig
+++ b/src/components/navigation/base/menu.twig
@@ -40,8 +40,17 @@
 {% set menu__attributes = menu__attributes|merge({
   'id': menu__base_class,
   'class': bem(menu__base_class, menu__modifiers, menu__blockname, menu__additional_classes),
-  'aria-labelledby': menu__base_class ~ '__label',
 }) %}
+
+{% if menu_is_breadcrumb %}
+    {% set menu__attributes = menu__attributes|merge({
+    'aria-label': menu__name,
+    }) %}
+{% else %}
+    {% set menu__attributes = menu__attributes|merge({
+    'aria-labelledby': menu__base_class ~ '__label',
+    }) %}
+{% endif %}
 
 {# Create a unique ID for each accordion item #}
 {% set unique_id = random('1234567890') ~ random('1234567890') ~ random('1234567890') ~ random('1234567890') %}
@@ -88,7 +97,9 @@
 {% import _self as menus %}
 
 <nav {{ add_attributes(menu__attributes) }}>
-	<h2 id="{{ menu__attributes['aria-labelledby'] }}" {{ bem('visually-hidden') }}>{{ menu__name }}</h2>
+    {% if menu_is_breadcrumb != 'true' %}
+       <h2 id="{{ menu__attributes['aria-labelledby'] }}" {{ bem('visually-hidden') }}>{{ menu__name }}</h2>
+    {% endif %}
 	{% block menu_prefix %}{% endblock %}
 	{% if menu__toggle is defined %}
 		{{ menu_toggle }}

--- a/src/components/navigation/breadcrumbs/breadcrumbs.twig
+++ b/src/components/navigation/breadcrumbs/breadcrumbs.twig
@@ -68,7 +68,7 @@
     menu__name: 'Breadcrumb',
     menu__list__type: 'ol',
     menu__attributes: breadcrumbs__attributes,
-    menu__is_breadcrumb: 'true',
+    menu_is_breadcrumb: 'true',
   } %}
     {% block menu_prefix %}
       {{ scroll_left }}

--- a/src/components/navigation/breadcrumbs/breadcrumbs.twig
+++ b/src/components/navigation/breadcrumbs/breadcrumbs.twig
@@ -68,6 +68,7 @@
     menu__name: 'Breadcrumb',
     menu__list__type: 'ol',
     menu__attributes: breadcrumbs__attributes,
+    menu__is_breadcrumb: 'true',
   } %}
     {% block menu_prefix %}
       {{ scroll_left }}


### PR DESCRIPTION
## Summary

- Update current breadcrumb design pattern to follow established design pattern

## How to review this pull request
- [x] Go to  https://deploy-preview-174--emulsify-ui-kit.netlify.app/?path=/story/components-navigation-breadcrumbs--breadcrumbs
- [x] Confirm there isn't a "Breadcrumb" visually hidden heading anymore, there should be a aria-label="Breadcrum" in the nav
- [x] Confirm there's an  aria-current="page" for the last item/current page
- [x] This should follow the [establish design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
