### PR TITLE
EMULSIF-546: Accessibility tweaks

### DIFF
--- a/src/components/tabs/_tab-content.twig
+++ b/src/components/tabs/_tab-content.twig
@@ -1,7 +1,7 @@
 
 {% set tab__modifiers = tab__modifiers|default([]) %}
 
-<div id="{{ tab__content__id }}" {{ bem(tab__content__base_class, tab__modifiers, tab__content__blockname, [current_class])}}>
+<div id="{{ tab__content__id }}" {{ bem(tab__content__base_class, tab__modifiers, tab__content__blockname, [current_class])}} role="tabpanel" aria-labelledby="{{ tab__id }}">
   {% block tab__content__components %}
     {{ tab__content }}
   {% endblock %}

--- a/src/components/tabs/_tab-label.twig
+++ b/src/components/tabs/_tab-label.twig
@@ -25,12 +25,13 @@
 {# if Storybook atoms example, add ul wrapper #}
 <li{{attributes}} {{ bem(tab__base_class, tab__modifiers, tab__blockname) }}>
 	{% set current_class = key == 0 ? ' is-active' : '' %}
+	{% set is_selected = key == 0 %}
 	{% if tab__icon %}
-		<a href="{{ tab__link }}" id="{{ tab__id }}" {{ bem('link', [], tab__base_class, [current_class])}}>
+		<a href="{{ tab__link }}" id="{{ tab__id }}" {{ bem('link', [], tab__base_class, [current_class])}} role="tab" aria-selected="{{ is_selected }}" tabindex="0">
 			<span {{ bem('text', [], tab__base_class, [current_class])}}>{{ tab__label }}</span>
 		</a>
 	{% else %}
-		<a href="{{ tab__link }}" id="{{ tab__id }}" {{ bem('link', [], tab__base_class, [current_class])}}>
+		<a href="{{ tab__link }}" id="{{ tab__id }}" {{ bem('link', [], tab__base_class, [current_class])}} role="tab" aria-selected="{{ is_selected }}" tabindex="0">
       <span {{ bem('text', [], tab__base_class, [current_class])}}>{{ tab__label }}</span>
     </a>
 	{% endif %}

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -59,7 +59,15 @@ Drupal.behaviors.tabs = {
               tabNavigationLinks[Number(activeIndex)].classList.remove(
                 'is-active',
               );
+              tabNavigationLinks[Number(activeIndex)].setAttribute(
+                'aria-selected',
+                'false',
+              );
               tabNavigationLinks[Number(index)].classList.add('is-active');
+              tabNavigationLinks[Number(index)].setAttribute(
+                'aria-selected',
+                'true',
+              );
               tabContentContainers[Number(activeIndex)].classList.remove(
                 'is-active',
               );
@@ -277,6 +285,25 @@ Drupal.behaviors.tabsNavScroll = {
             mouseNav('right');
           } else {
             mouseNav('left');
+          }
+        });
+
+        // Make scroll buttons accessible
+        control.removeAttribute('aria-hidden'); // Remove hidden for screen readers
+        control.setAttribute('tabindex', '0'); // Make keyboard focusable
+        control.setAttribute('role', 'button'); // Explicit role
+        control.setAttribute(
+          'aria-label',
+          control.classList.contains('tabs__scroll--right')
+            ? 'Scroll Right'
+            : 'Scroll Left',
+        );
+
+        // Keyboard support
+        control.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            control.click(); // Trigger existing click behavior
           }
         });
       });

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -74,6 +74,7 @@
     opacity: 0;
     visibility: hidden;
     padding: 0;
+    cursor: pointer;
   }
 
   &--left {

--- a/src/components/tabs/tabs.twig
+++ b/src/components/tabs/tabs.twig
@@ -75,7 +75,7 @@
 <div {{ bem(tabs__base_class, tabs__modifiers, tabs__blockname, ['no-js']) }} data-tabs-display="{{ tabs__display }}">
 	<div {{ bem('wrapper', tabs__modifiers, tabs__base_class) }}>
 		{{ scroll_left }}
-		<ul {{ bem('nav', [], tabs__base_class) }}>
+		<ul {{ bem('nav', [], tabs__base_class) }} role="tablist">
 			{% for key, tab in tabs %}
 				{% set tab__name = tab.tab__label|lower|replace({' ': '-', '&': 'and'}) ~ '-' ~ key %}
 				{% include "@components/tabs/_tab-label.twig" with {
@@ -102,6 +102,7 @@
 					tab__blockname: tabs__base_class,
 					tab__content__id: '#' ~ tab__name,
 					tab__content: tab.tab__content,
+					tab__id: tab__name ~ '-tab',
 				} %}
 			{% endfor %}
 		{% endblock %}


### PR DESCRIPTION
## Summary
This PR fixes/implements the following **bugs**

- The "Expand All" and "Collapse All" buttons do not indicate their disabled state programmatically when all accordions are already expanded or collapsed.The same is indicated visually using a different color  
- The tab widget has the below issues:
     1. It is not programmatically implemented as a proper tab component. Tabs are announced as links by screen readers
     2. The arrow icon used to access remaining tabs is not keyboard-operable, making it inaccessible to keyboard and screen reader users

## Tickets
https://app.clickup.com/t/36718269/EMULSIF-438
https://app.clickup.com/t/36718269/EMULSIF-439


## How to review this pull request
- [x] Visit the following https://deploy-preview-179--emulsify-ui-kit.netlify.app/
- [x] Go to an Accordion and confirm the "Expand All" and "Collapse All" buttons programmatically indicate their disabled state using aria-disabled="true"
- [x] Now visit Tabs and confirm Tabs are correctly announced as "tabs" by screen readers along with selected state. Users should be able to operate the arrow icon using keyboard
